### PR TITLE
Add js_glightbox_caption.html5 template

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,6 @@
 Contao GLightbox
 =========================
 
-Contao extension to integrate [GLightbox](https://biati-digital.github.io/glightbox/). To enable, activate the `js_glightbox` JavaScript template in your page layout (disable any other lightbox integrations). Create your own custom template in order to customise the GLightbox [options](https://github.com/biati-digital/glightbox/blob/master/README.md#lightbox-options).
+Contao extension to integrate [GLightbox](https://biati-digital.github.io/glightbox/).
+
+To enable, activate either the `js_glightbox` or the `js_glightbox_caption` (to display image caption in lightbox) JavaScript template in your page layout. Make sure to disable any other lightbox integrations. Create your own custom template in order to customise the GLightbox [options](https://github.com/biati-digital/glightbox/blob/master/README.md#lightbox-options).

--- a/contao/templates/js_glightbox_caption.html5
+++ b/contao/templates/js_glightbox_caption.html5
@@ -1,0 +1,25 @@
+<?php
+
+use Contao\Template;
+
+$GLOBALS['TL_CSS']['glightbox'] = 'bundles/contaoglightbox/css/glightbox.min.css|static';
+echo Template::generateScriptTag('bundles/contaoglightbox/js/glightbox.min.js', false, null);
+
+?>
+<script>
+(function(){
+  'use strict';
+  document.querySelectorAll('a[data-lightbox]').forEach((element) => {
+    if (!!element.dataset.lightbox) {
+      element.setAttribute('data-gallery', element.dataset.lightbox);
+      const caption = element.nextElementSibling;
+      if (!!caption) {
+        element.setAttribute('data-glightbox', 'title: '+caption.textContent);
+      }
+    }
+  });
+  GLightbox({
+    selector: 'a[data-lightbox]'
+  });
+})();
+</script>


### PR DESCRIPTION
…to include figcaption as glightbox description.

I think it is a common requirement to display image captions in the lightbox. So why not offer this option out of the box?