### PR TITLE
Add Symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=7.1",
         "contao/core-bundle": "^4.9 || ^5.0",
-        "symfony/http-kernel": "^4.4 || ^5.1 || ^6.0"
+        "symfony/http-kernel": "^4.4 || ^5.1 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Is there any reason to not include Symfony 7? I tested this in Contao 5.3 and 5.4