### PR TITLE
Output js_glightbox in modern (Twig) page layouts

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,0 +1,13 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    InspiredMinds\ContaoGLightbox\EventListener\AddGLightboxAssetsListener:
+        arguments:
+            - '@contao.framework'
+        tags:
+            # LayoutEvent only exists in modern Contao; register via string so the
+            # class is never resolved where it is missing.
+            - { name: kernel.event_listener, event: 'Contao\CoreBundle\Event\LayoutEvent', method: onLayout }

--- a/src/DependencyInjection/ContaoGLightboxExtension.php
+++ b/src/DependencyInjection/ContaoGLightboxExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Contao GLightbox extension.
+ *
+ * (c) inspiredminds
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace InspiredMinds\ContaoGLightbox\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+class ContaoGLightboxExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $loader = new YamlFileLoader($container, new FileLocator(\dirname(__DIR__, 2).'/config'));
+        $loader->load('services.yaml');
+    }
+}

--- a/src/EventListener/AddGLightboxAssetsListener.php
+++ b/src/EventListener/AddGLightboxAssetsListener.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Contao GLightbox extension.
+ *
+ * (c) inspiredminds
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace InspiredMinds\ContaoGLightbox\EventListener;
+
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\FrontendTemplate;
+use Contao\LayoutModel;
+use Contao\StringUtil;
+
+/**
+ * Outputs the `js_glightbox` template for MODERN Twig page layouts.
+ *
+ * Modern layouts do not process the layout's JavaScript templates (the `scripts`
+ * field), so the classic activation ("enable the js_glightbox JavaScript
+ * template in your page layout") has no effect there. This listener renders the
+ * very same template when it is enabled in the layout, so the behaviour – and
+ * any custom js_glightbox template the user created – is identical to the classic
+ * layout. The classic `fe_page` layout keeps rendering the template itself, and a
+ * page is either classic or modern, so the template is never output twice.
+ *
+ * Registered via services.yaml with the event name as a string and an `object`
+ * parameter, so Contao\CoreBundle\Event\LayoutEvent is never resolved on Contao
+ * versions that do not provide it.
+ */
+class AddGLightboxAssetsListener
+{
+    public function __construct(private readonly ContaoFramework $framework)
+    {
+    }
+
+    public function onLayout(object $event): void
+    {
+        if (!method_exists($event, 'getLayout')) {
+            return;
+        }
+
+        $layout = $event->getLayout();
+
+        if (!$layout instanceof LayoutModel) {
+            return;
+        }
+
+        $scripts = StringUtil::deserialize($layout->scripts, true);
+
+        if (!\in_array('js_glightbox', $scripts, true)) {
+            return;
+        }
+
+        $this->framework->initialize();
+
+        /** @var FrontendTemplate $template */
+        $template = $this->framework->createInstance(FrontendTemplate::class, ['js_glightbox']);
+
+        // parse() also registers the stylesheet via $GLOBALS['TL_CSS'] (set inside the template).
+        $GLOBALS['TL_BODY']['js_glightbox'] = $template->parse();
+    }
+}


### PR DESCRIPTION
In modern Twig page layouts the layout's JavaScript templates (the `scripts` field) are not processed, so enabling the `js_glightbox` template in the page layout has no effect there — neither the stylesheet, the library nor the init script are output. (Related to #10, which fixed the asset path but not this case for pure modern layouts.)

This adds a `LayoutEvent` listener that renders the **same** `js_glightbox` template when it is enabled in the layout, so the behaviour — including a custom `js_glightbox` template and the CSP nonce — is identical to the classic `fe_page` layout. The classic layout keeps rendering the template itself, and a page is either classic or modern, so it is never output twice.

The bundle had no dependency-injection extension, so a minimal one was added to load `config/services.yaml`. The listener is registered with the event name as a string and an `object` parameter, so `Contao\CoreBundle\Event\LayoutEvent` is never resolved on versions that do not provide it.
